### PR TITLE
feat: multi-year totals and tax-year exports

### DIFF
--- a/docs/architecture/architecture-overview.md
+++ b/docs/architecture/architecture-overview.md
@@ -4,7 +4,7 @@ This document describes the current architecture of the Biruk's Egg Deliveries P
 
 - **Status**: Draft
 - **Owner**: repo maintainers
-- **Last updated**: 2025-12-19
+- **Last updated**: 2025-12-23
 - **Type**: Reference
 - **Scope**: system architecture, storage design, and key data flows
 - **Non-goals**: UI walkthroughs or operational procedures
@@ -19,7 +19,7 @@ This document describes the current architecture of the Biruk's Egg Deliveries P
 ## High-level architecture
 
 - **Frontend**: Standalone Angular app with three main pages:
-  - Home (`src/app/pages/home.component.*`)
+  - Home (`src/app/pages/home.component.*`) with the tax-year selector for totals and exports.
   - Route planner (`src/app/pages/route-planner.component.*`)
   - Delivery run (`src/app/pages/delivery-run.component.*`)
 - **Routing**: Defined in `src/app/app.routes.ts` with routes for home, planner, and run views.
@@ -47,14 +47,14 @@ This document describes the current architecture of the Biruk's Egg Deliveries P
 
 - **CSV parsing**: Imports use PapaParse in `home.component.ts`.
 - **Baseline imports**: Read delivery rows into the local database.
-- **Backups**: `BackupService` exports CSV using Web Share when available, or a local file download.
+- **Backups**: `BackupService` exports CSV using Web Share when available, or a local file download. Totals are scoped to the selected tax year and the filename includes a tax-year suffix.
 - **Restore**: Backup CSV restores replace deliveries, routes, run history, and import state in one operation.
 - **Formats**: See `docs/reference/csv-format.md` for column rules and `RowType` handling.
 
 ## Run history and donation totals
 
 - Completed runs are snapshotted into `runs` and `runEntries` via `StorageService.completeRun`.
-- Donation totals are computed from per-event receipts using the global formula and stored on export.
+- Donation totals are computed from per-event receipts using the global formula and stored on export, with optional tax-year filtering.
 - See decisions and reference docs for the rationale and formula details.
 
 ## Offline behavior

--- a/docs/ops/backup-restore.md
+++ b/docs/ops/backup-restore.md
@@ -4,7 +4,7 @@ Runbook for backing up data and restoring from a backup CSV.
 
 - **Status**: Draft
 - **Owner**: repo maintainers
-- **Last updated**: 2025-12-19
+- **Last updated**: 2025-12-23
 - **Type**: How-to
 - **Scope**: data backup and restore workflows
 - **Non-goals**: changing CSV formats or implementing new storage features
@@ -26,8 +26,9 @@ Runbook for backing up data and restoring from a backup CSV.
 ### Backup (CSV)
 
 1. Go to Home.
-2. Use **Backup (CSV)** to export.
-3. Save the file in a safe location.
+2. Confirm the correct **Tax year** is selected (totals and filename follow it).
+3. Use **Backup (CSV)** to export.
+4. Save the file in a safe location.
 
 ### Restore (CSV)
 

--- a/docs/reference/csv-format.md
+++ b/docs/reference/csv-format.md
@@ -4,7 +4,7 @@ Reference for the CSV files the app imports, exports, and restores. Covers basel
 
 - **Status**: Draft
 - **Owner**: repo maintainers
-- **Last updated**: 2025-12-22
+- **Last updated**: 2025-12-23
 - **Type**: Reference
 - **Scope**: CSV import/export schema and parsing rules
 - **Non-goals**: UI steps for importing/exporting CSV files
@@ -18,6 +18,8 @@ The app supports two CSV variants:
 - Backup exports that include run history and one-off events using `RowType`.
 
 Baseline imports read delivery rows only. Backup restores read all row types and rebuild history.
+
+Backup exports include all history rows, while totals columns are scoped to the tax year selected at export time.
 
 ## Column conventions
 
@@ -105,6 +107,8 @@ Totals are computed and exported as:
 - `TotalDonation`
 - `TotalDozens`
 - `TotalDeductibleContribution`
+
+Totals reflect the tax year selected on Home at export time. Backup filenames include a `-tax-year-YYYY` suffix to show the year used for totals.
 
 Exports without an import state use `TotalTaxableDonation` instead of `TotalDeductibleContribution`.
 

--- a/docs/user/user-guide.md
+++ b/docs/user/user-guide.md
@@ -4,7 +4,7 @@ How to use the app day‑to‑day: importing routes, planning, running deliverie
 
 - **Status**: Draft
 - **Owner**: repo maintainers
-- **Last updated**: 2025-12-22
+- **Last updated**: 2025-12-23
 - **Type**: How-to
 - **Scope**: end‑to‑end app usage for delivery weeks
 - **Non-goals**: developer setup or architectural detail
@@ -32,17 +32,19 @@ For each delivery week:
      - All the original columns from your file.
      - All completed runs the app knows about.
      - All one‑off deliveries and donations.
-     - Running totals for dozens, donations, and the deductible charitable contribution per person.
+     - Running totals for dozens, donations, and the deductible charitable contribution per person for the selected tax year.
+
+Set the tax year on Home before exporting so the totals and filename match the year you need.
 
 Deductible totals use a global formula: total donations minus the baseline value of delivered dozens at the time of each delivery (never below zero).
 
-You can run many times per year on the same schedule. The app keeps all of that history and totals until you choose to import a brand new CSV.
+You can run many times per year on the same schedule. The app keeps all of that history and totals; if it sees more than one year of data, Home shows a warning to export and start a new file for the new year.
 
 ---
 
 ## 2. Home Page
 
-The Home page has three main sections:
+The Home page has four main sections:
 
 - **Import / Backup / Help**
   - **Import CSV**: load a route file from your device.
@@ -55,6 +57,10 @@ The Home page has three main sections:
   - The page also shows:
     - **Last backup** timestamp (only when the last backup matches the current data).
     - **Imported** timestamp for when the current dataset was loaded.
+
+- **Tax year**
+  - **Tax year selector**: choose the year used for totals and exports.
+  - If the app detects multiple years of data, it shows a warning to export and start a new file for the new year.
 
 - **Settings**
   - **Dark mode**: toggle between light and dark themes.
@@ -180,14 +186,14 @@ You can run the same schedule again later. Each completed run adds another entry
 
 From the Planner hidden menu:
 
-  - **Donation**:
+- **Donation**:
     - Record a donation for that person that is **not tied to a specific route run**.
     - You choose method and amount; the app computes the deductible charitable contribution (amount minus the suggested donation).
-    - Choose an **event date** (defaults to today). Dates must be within the current calendar year.
+    - Choose an **event date** (defaults to today). Dates must be within the range shown in the picker (earliest data year through next year).
 - **Delivery**:
   - Record an extra delivery outside of the normal schedule.
   - Allows you to specify dozens and donation for that one‑off event.
-  - Choose an **event date** (defaults to today). Dates must be within the current calendar year.
+  - Choose an **event date** (defaults to today). Dates must be within the range shown in the picker (earliest data year through next year).
 
 These one‑offs:
 
@@ -217,13 +223,13 @@ These one‑offs:
 
 ## 8. Exporting for Taxes and Records
 
-The **Backup (CSV)** export is your master snapshot.
+The **Backup (CSV)** export is your master snapshot. Totals are scoped to the tax year selected on Home, and the filename includes that tax year.
 
 Per person, it includes:
 
 - All original columns from your CSV (for reference).
 - Run‑level state for each run (depending on how many runs you’ve completed).
-- Cumulative totals:
+- Totals for the selected tax year:
   - `TotalDozens` – dozens from:
     - Imported totals from your original file (if present),
     - All runs completed in the app,
@@ -250,6 +256,7 @@ For each run:
    - Tap **Backup now**.
    - Tap **Complete run**.
 5. At year‑end:
+   - Set the tax year on Home.
    - Export a final CSV.
    - Use it to build donor and tax statements.
 

--- a/src/app/pages/home.component.html
+++ b/src/app/pages/home.component.html
@@ -56,6 +56,36 @@
   <div class="error" *ngIf="errorMessage">{{ errorMessage }}</div>
 </section>
 
+<section class="card settings-card tax-year-card">
+  <div class="settings-row">
+    <div>
+      <label class="settings-title" for="tax-year-select">Tax year</label>
+      <div class="text-muted settings-subtitle" id="tax-year-help">
+        Totals and backups use this year.
+      </div>
+    </div>
+    <div class="select-row">
+      <select
+        id="tax-year-select"
+        class="form-control compact"
+        [value]="selectedTaxYear"
+        (change)="onTaxYearChange($event)"
+        [attr.aria-describedby]="hasMultiYearData ? 'tax-year-help tax-year-warning' : 'tax-year-help'"
+      >
+        @for (year of taxYearOptions; track year) {
+          <option [value]="year">{{ year }}</option>
+        }
+      </select>
+    </div>
+  </div>
+  @if (hasMultiYearData) {
+    <div class="tax-year-warning" id="tax-year-warning">
+      Multiple years detected. Export and start a new file for the new year to
+      avoid tax mix-ups.
+    </div>
+  }
+</section>
+
 <section class="card settings-card">
   <div class="settings-row">
     <div>

--- a/src/app/pages/home.component.scss
+++ b/src/app/pages/home.component.scss
@@ -23,6 +23,16 @@
   gap: var(--spacing-2);
 }
 
+.tax-year-card .select-row {
+  justify-content: flex-end;
+}
+
+.tax-year-warning {
+  color: var(--color-danger);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+}
+
 .build-card {
   margin-top: var(--spacing-3);
 }

--- a/src/app/pages/route-planner.component.html
+++ b/src/app/pages/route-planner.component.html
@@ -344,8 +344,8 @@
               <input
                 class="form-control"
                 type="date"
-                [min]="currentYearStart"
-                [max]="currentYearEnd"
+                [min]="oneOffDateMin"
+                [max]="oneOffDateMax"
                 [ngModel]="oneOffDonationDate"
                 (ngModelChange)="onOneOffDonationDateChange($event)"
                 name="oneOffDonationDate"
@@ -417,8 +417,8 @@
               <input
                 class="form-control"
                 type="date"
-                [min]="currentYearStart"
-                [max]="currentYearEnd"
+                [min]="oneOffDateMin"
+                [max]="oneOffDateMax"
                 [ngModel]="oneOffDeliveryDate"
                 (ngModelChange)="onOneOffDeliveryDateChange($event)"
                 name="oneOffDeliveryDate"

--- a/src/app/services/backup.service.spec.ts
+++ b/src/app/services/backup.service.spec.ts
@@ -20,6 +20,10 @@ describe('BackupService totals with mini route', () => {
     backup = TestBed.inject(BackupService);
   });
 
+  afterEach(() => {
+    localStorage.removeItem('lastImportAt');
+  });
+
   it('computes zero totals when nothing has been delivered or donated', async () => {
     const deliveries = await storage.getAllDeliveries();
     const totals = (backup as any).computeTotalsByBase(deliveries);
@@ -78,5 +82,143 @@ describe('BackupService totals with mini route', () => {
     // one-off donation is fully deductible.
     const expectedDeductible = 10;
     expect(c1Totals!.taxable).toBeCloseTo(expectedDeductible, 5);
+  });
+
+  it('filters totals by tax year across runs, one-offs, and live deliveries', async () => {
+    const rate = storage.getSuggestedRate();
+    const deliveries = await storage.getAllDeliveries();
+    const target = deliveries.find((d) => d.id === 'c1-r1');
+    if (!target) {
+      throw new Error('Missing delivery c1-r1');
+    }
+
+    target.status = 'delivered';
+    target.deliveredDozens = 2;
+    target.dozens = 2;
+    target.deliveredAt = '2025-04-10T12:00:00.000Z';
+    target.donation = {
+      status: 'Donated',
+      method: 'cash',
+      amount: 2 * rate,
+      suggestedAmount: 2 * rate,
+      taxableAmount: 0,
+      date: target.deliveredAt
+    };
+    target.oneOffDonations = [
+      {
+        status: 'Donated',
+        method: 'venmo',
+        amount: 5,
+        suggestedAmount: 5,
+        date: '2025-02-01'
+      }
+    ];
+    target.oneOffDeliveries = [
+      {
+        deliveredDozens: 1,
+        donation: {
+          status: 'Donated',
+          method: 'cash',
+          amount: 4,
+          suggestedAmount: 4,
+          date: '2025-03-01'
+        },
+        date: '2025-03-01'
+      }
+    ];
+
+    const runEntries = [
+      {
+        id: 'run-2024-c1',
+        runId: '2024-06-01_2024-06-01T00:00:00.000Z',
+        baseRowId: 'c1',
+        name: 'Alice',
+        address: '123 Main St',
+        city: 'Testville',
+        state: 'TS',
+        zip: '12345',
+        status: 'delivered' as const,
+        dozens: 1,
+        deliveryOrder: 0,
+        donationStatus: 'Donated' as const,
+        donationMethod: 'cash' as const,
+        donationAmount: 6,
+        taxableAmount: 0,
+        eventDate: '2024-06-15T12:00:00.000Z'
+      }
+    ];
+
+    const totals2024 = (backup as any).computeTotalsByBase(
+      deliveries,
+      runEntries,
+      undefined,
+      2024
+    ) as Map<string, { donation: number; dozens: number; taxable: number }>;
+    const c1Totals2024 = totals2024.get('c1');
+    expect(c1Totals2024?.donation ?? 0).toBeCloseTo(6, 5);
+    expect(c1Totals2024?.dozens ?? 0).toBe(1);
+    expect(c1Totals2024?.taxable ?? 0).toBeCloseTo(0, 5);
+
+    const totals2025 = (backup as any).computeTotalsByBase(
+      deliveries,
+      runEntries,
+      undefined,
+      2025
+    ) as Map<string, { donation: number; dozens: number; taxable: number }>;
+    const c1Totals2025 = totals2025.get('c1');
+    const expected2025Donation = 2 * rate + 5 + 4;
+    expect(c1Totals2025?.donation ?? 0).toBeCloseTo(expected2025Donation, 5);
+    expect(c1Totals2025?.dozens ?? 0).toBe(3);
+    expect(c1Totals2025?.taxable ?? 0).toBeCloseTo(5, 5);
+
+    const totalsAll = (backup as any).computeTotalsByBase(
+      deliveries,
+      runEntries
+    ) as Map<string, { donation: number; dozens: number; taxable: number }>;
+    const c1TotalsAll = totalsAll.get('c1');
+    expect(c1TotalsAll?.donation ?? 0).toBeCloseTo(
+      expected2025Donation + 6,
+      5
+    );
+    expect(c1TotalsAll?.dozens ?? 0).toBe(4);
+  });
+
+  it('includes import totals only for the baseline year when filtered', async () => {
+    localStorage.setItem('lastImportAt', '2024-05-01T00:00:00.000Z');
+    const deliveries = await storage.getAllDeliveries();
+    const importState = {
+      headers: [
+        'BaseRowId',
+        'TotalDonation',
+        'TotalDozens',
+        'TotalDeductibleContribution'
+      ],
+      rowsByBaseRowId: {
+        c1: ['c1', '20', '4', '6']
+      },
+      mode: 'baseline' as const
+    };
+
+    const totals2024 = (backup as any).computeTotalsByBase(
+      deliveries,
+      [],
+      importState,
+      2024
+    ) as Map<string, { donation: number; dozens: number; taxable: number }>;
+    const c1Totals2024 = totals2024.get('c1');
+    expect(c1Totals2024?.donation ?? 0).toBe(20);
+    expect(c1Totals2024?.dozens ?? 0).toBe(4);
+    expect(c1Totals2024?.taxable ?? 0).toBe(6);
+
+    const totals2025 = (backup as any).computeTotalsByBase(
+      deliveries,
+      [],
+      importState,
+      2025
+    ) as Map<string, { donation: number; dozens: number; taxable: number }>;
+    const c1Totals2025 = totals2025.get('c1');
+    expect(c1Totals2025?.donation ?? 0).toBe(0);
+    expect(c1Totals2025?.dozens ?? 0).toBe(0);
+    expect(c1Totals2025?.taxable ?? 0).toBe(0);
   });
 });

--- a/src/app/services/usage-scenario-totals.spec.ts
+++ b/src/app/services/usage-scenario-totals.spec.ts
@@ -75,6 +75,40 @@ describe('Usage scenario totals (data-level)', () => {
     expect(c2Totals!.dozens).toBe(0);
   });
 
+  it('filters one-off totals by tax year', async () => {
+    await storage.appendOneOffDonation('c2-r1', {
+      status: 'Donated' as const,
+      method: 'cash' as const,
+      amount: 5,
+      suggestedAmount: 5,
+      date: '2024-11-10'
+    });
+    await storage.appendOneOffDonation('c2-r2', {
+      status: 'Donated' as const,
+      method: 'venmo' as const,
+      amount: 7,
+      suggestedAmount: 7,
+      date: '2025-01-10'
+    });
+
+    const deliveries = await storage.getAllDeliveries();
+    const totals2024 = (backup as any).computeTotalsByBase(
+      deliveries,
+      [],
+      undefined,
+      2024
+    ) as Map<string, { donation: number; dozens: number; taxable: number }>;
+    const totals2025 = (backup as any).computeTotalsByBase(
+      deliveries,
+      [],
+      undefined,
+      2025
+    ) as Map<string, { donation: number; dozens: number; taxable: number }>;
+
+    expect(totals2024.get('c2')?.donation ?? 0).toBeCloseTo(5, 5);
+    expect(totals2025.get('c2')?.donation ?? 0).toBeCloseTo(7, 5);
+  });
+
   it('totals one-off deliveries only (dozens + donation)', async () => {
     const rate = storage.getSuggestedRate();
 

--- a/src/app/utils/date-utils.ts
+++ b/src/app/utils/date-utils.ts
@@ -46,6 +46,18 @@ export function normalizeEventDate(
   return Number.isNaN(parsed.getTime()) ? value : parsed.toISOString();
 }
 
+export function getEventYear(
+  raw?: string | number | null,
+  fallbackDate: Date = new Date()
+): number {
+  const normalized = normalizeEventDate(raw);
+  if (!normalized) return fallbackDate.getFullYear();
+  const parsed = new Date(normalized);
+  return Number.isNaN(parsed.getTime())
+    ? fallbackDate.getFullYear()
+    : parsed.getFullYear();
+}
+
 export function toSortableTimestamp(raw?: string): number {
   const normalized = normalizeEventDate(raw);
   if (!normalized) return 0;


### PR DESCRIPTION
## Summary
- add Home tax-year selector with multi-year warning and persist selection
- filter totals by tax year and suffix backup filename when set
- expand one-off date validation to a multi-year range and refresh docs/tests

## Testing
- npm test -- --watch=false --browsers=ChromeHeadless (failed: existing scenario runner + usage scenario tests call toCsv without totals map; not addressed)
- npm run build (pass with route-planner.component.scss budget warning)

Fixes #16
