### PR TITLE
Allow editing one-off receipt dates

### DIFF
--- a/src/app/pages/route-planner.component.html
+++ b/src/app/pages/route-planner.component.html
@@ -573,6 +573,28 @@
         <div class="inline-donation-body">
           <div class="card">
             <div class="new-form">
+              @if (editingRunEntry?.runId === 'oneoff') {
+                <label class="date-field">
+                  {{ editingRunEntry?.oneOffKind === 'donation' ? 'Donation date' : 'Delivery date' }}
+                  <input
+                    class="form-control"
+                    type="date"
+                    [min]="oneOffDateMin"
+                    [max]="oneOffDateMax"
+                    [ngModel]="runEntryDate"
+                    (ngModelChange)="onRunEntryDateChange($event)"
+                    name="runEntryDate"
+                    required
+                    [attr.aria-invalid]="runEntryDateError ? 'true' : null"
+                    [attr.aria-describedby]="runEntryDateError ? 'run-entry-date-error' : null"
+                  />
+                </label>
+                @if (runEntryDateError) {
+                  <p class="error-text" id="run-entry-date-error">
+                    {{ runEntryDateError }}
+                  </p>
+                }
+              }
               <label *ngIf="editingRunEntry?.runId !== 'oneoff'">
                 Status
                 <select
@@ -679,6 +701,7 @@
               <button
                 class="btn btn-primary"
                 type="button"
+                [disabled]="editingRunEntry?.runId === 'oneoff' && !!runEntryDateError"
                 (click)="saveRunEntryEdit()"
               >
                 Save

--- a/src/app/services/storage.service.ts
+++ b/src/app/services/storage.service.ts
@@ -248,6 +248,7 @@ export class StorageService {
       donationMethod?: DonationMethod;
       donationAmount: number;
       suggestedAmount?: number;
+      date?: string;
     }
   ): Promise<void> {
     const now = new Date().toISOString();
@@ -272,6 +273,9 @@ export class StorageService {
     if (patch.suggestedAmount != null) {
       next.suggestedAmount = patch.suggestedAmount;
     }
+    if (patch.date != null) {
+      next.date = normalizeEventDate(patch.date) ?? existing.date ?? now;
+    }
     next.taxableAmount = computeOneOffDonationTaxableAmount(next);
     list[index] = next;
     await this.db.deliveries.update(deliveryId, {
@@ -290,6 +294,7 @@ export class StorageService {
       donationMethod?: DonationMethod;
       donationAmount: number;
       suggestedAmount?: number;
+      date?: string;
     }
   ): Promise<void> {
     const now = new Date().toISOString();
@@ -328,11 +333,16 @@ export class StorageService {
       donation.taxableAmount = computeTaxableAmount(donation);
     }
 
+    const normalizedDate =
+      patch.date != null ? normalizeEventDate(patch.date) ?? existing.date ?? now : existing.date ?? now;
+    if (donation) {
+      donation.date = normalizedDate;
+    }
     list[index] = {
       ...existing,
       deliveredDozens: dozens,
       donation,
-      date: existing.date ?? now
+      date: normalizedDate
     };
 
     await this.db.deliveries.update(deliveryId, {


### PR DESCRIPTION
## Summary
- add date editing in one-off receipt edit flow with validation
- persist one-off date edits in storage and sync delivery donation dates
- add coverage for updated EventDate exports

## Testing
- npm run build (warn: route-planner.component.scss over budget by ~905 bytes)
- npm test (fails: BackupService.toCsv TypeError; see #42)

Fixes #45

## Retrospective
- Worked: reused existing one-off date validation + normalization.
- Hurt: Karma port permissions and existing scenario-runner failures.
- Next: stabilize BackupService.toCsv scenario-runner tests (#42).