### PR TITLE
feat: release info and update prompt

### DIFF
--- a/.github/prompts/feature.prompt.md
+++ b/.github/prompts/feature.prompt.md
@@ -105,8 +105,10 @@ Documentation gates (do not skip):
 
 1. Follow `docs/dev/workflows/feature-delivery.md` (Finish) plus testing + quality workflows.
 2. Verify docs impact is resolved and required regression packs/scenarios are recorded.
-3. Run the multi-repo guard before push/PR/merge, then proceed without an extra confirmation if values match.
-4. Push and open a PR via `.github/prompts/pr.prompt.md`, then review/merge per `docs/dev/workflows/code-review.md` and clean up the branch.
+3. Confirm `public/release-notes.json` is updated for user-visible changes before opening the PR.
+4. Refresh build info for the Home footer (`npm run build` or `node scripts/write-build-info.js`), verify the timestamp updates after reload, and restore `public/build-info.json` before commit.
+5. Run the multi-repo guard before push/PR/merge, then proceed without an extra confirmation if values match.
+6. Push and open a PR via `.github/prompts/pr.prompt.md`, then review/merge per `docs/dev/workflows/code-review.md` and clean up the branch.
 
 ## action=review
 

--- a/.github/prompts/release.prompt.md
+++ b/.github/prompts/release.prompt.md
@@ -24,6 +24,7 @@ General rules:
 - ALWAYS inspect `git status -sb` and the diff before doing anything.
 - Generate the commit message from the changes (I won’t type it).
 - If I don’t provide a version tag, propose the next `vYYYY.M.P` and ask me to confirm.
+- Require `public/release-notes.json` to be updated for the version being shipped.
 - Ask whether to run tests before shipping.
 - Require full regression packs (TP-01 through TP-11) and usage scenarios before tagging or deploying; if skipping, get explicit confirmation and record a waiver (what was skipped, why, who approved) in release notes or a PR comment.
 - If any command fails, stop and report the error and repo state.
@@ -46,8 +47,11 @@ Supported commands I will say to you:
      - Proposed next tag (`vYYYY.M.P`) with reasoning
      - Draft release notes (Summary / Changes / Notes / Device checklist for TP-11)
      - Regression pack readiness (TP-01 through TP-11 + usage scenarios)
+     - Release notes update status (confirm `public/release-notes.json` is updated)
    - Ask: "Update docs before release? (yes/no)"
      - If yes, pause and invoke the docs workflow (`/docs action=update`) then re-check status.
+   - Ask: "Are release notes updated for this version? (yes/no)"
+     - If no, stop and request an update before shipping.
    - Do NOT run git/build/deploy commands.
 
 2. "ship it" (optionally with a version, e.g. "ship it v2025.12.0")
@@ -59,15 +63,17 @@ Supported commands I will say to you:
    2. If no version was provided:
       - Inspect existing tags to detect `vYYYY.M.P`.
       - Propose the next tag and ask for confirmation.
-   3. Ask: "Run tests before shipping? (yes/no)"
+   3. Ask: "Are release notes updated for this version? (yes/no)"
+      - If no, stop and request an update before shipping.
+   4. Ask: "Run tests before shipping? (yes/no)"
       - If yes, run `npm test` and stop on failures.
-   4. Ask: "Run full regression packs (TP-01 through TP-11) and usage scenarios? (yes/no)"
+   5. Ask: "Run full regression packs (TP-01 through TP-11) and usage scenarios? (yes/no)"
       - If no, stop and request explicit approval to proceed without full regression.
-   5. Stage all changes, commit, tag, and push default branch + tags.
-   6. Build and deploy:
+   6. Stage all changes, commit, tag, and push default branch + tags.
+   7. Build and deploy:
       - Run the build command.
       - If build succeeds, run the deploy command so `gh-pages` reflects this tag.
-   7. Report:
+   8. Report:
       - Commit SHA
       - Tag name
       - Confirmation that GH Pages was deployed from that tag
@@ -78,9 +84,10 @@ Supported commands I will say to you:
    Behavior:
 
    1. Run the same non-mutating release prep as "status".
-   2. Stage all changes and commit with the proposed message.
-   3. Push the default branch.
-   4. Report that GH Pages remains on the previous deployed tag.
+   2. Confirm release notes are updated for this version; stop if missing.
+   3. Stage all changes and commit with the proposed message.
+   4. Push the default branch.
+   5. Report that GH Pages remains on the previous deployed tag.
 
 4. "roll it back"
    Meaning: deploy the previous tag to GH Pages.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ Follow them alongside system and developer instructions.
 
 - **Status**: Stable
 - **Owner**: repo maintainers
-- **Last updated**: 2026-01-05
+- **Last updated**: 2026-01-29
 - **Type**: Reference
 - **Scope**: agent behavior and repo-specific standards
 - **Non-goals**: replace system/developer instructions or code-level standards
@@ -104,5 +104,6 @@ Canonical workflows:
 - Added a worktree safety check requirement so agents confirm how to handle existing changes before switching tasks.
 - Added a docs-impact gate so documentation updates are completed or tracked with a doc child issue.
 - Added a change-impact summary gate to capture impacted flows, files, automation, and TP-xx packs before coding.
+- Added a release-notes update gate so feature finish and release flows keep in-app notes current.
 - Added explicit merge cleanup steps (delete local branch, prune refs) in merge workflows/prompts.
 - Clarified that explicit workflow invocations authorize standard mutations after guard checks.

--- a/docs/dev/workflows/feature-delivery.md
+++ b/docs/dev/workflows/feature-delivery.md
@@ -4,7 +4,7 @@ Use this workflow to deliver a feature tracked by a parent issue and child issue
 
 - **Status**: Draft
 - **Owner**: repo maintainers
-- **Last updated**: 2026-01-05
+- **Last updated**: 2026-01-30
 - **Type**: How-to
 - **Scope**: feature delivery from issue breakdown to PR
 - **Non-goals**: issue creation/triage, release and deployment
@@ -35,6 +35,7 @@ Use this workflow to deliver a feature tracked by a parent issue and child issue
 - If child issues are missing, use `/issues action=breakdown` to create them.
 - Use the docs prompt and documentation style guide when updating docs.
 - If docs are required but deferred, create a doc child issue and link it in the parent issue's **Docs impact** section.
+- Update `public/release-notes.json` for user-visible changes before `feature finish`.
 - Run quality checks per `docs/dev/workflows/quality.md` before opening a PR.
 - If tests are known failing, skip them only with an explicit PR note and a follow-up issue.
 - Confirm branch protection and rulesets for `main` before merging so required checks match available CI.
@@ -96,6 +97,8 @@ Use this once per repo to keep `main` safe without blocking work.
    - Use `/branch action=sync` as needed.
 6. Finish the feature:
    - Run `/feature action=finish` or `feature finish`.
+   - Update `public/release-notes.json` with a user-friendly summary of the change.
+   - Refresh build info for the Home footer: run `npm run build` (or `node scripts/write-build-info.js`), confirm the timestamp updates after a reload, then restore `public/build-info.json` before committing.
    - Run the required regression packs (per `docs/testing/regression-tests.md`) and record TP-xx IDs; update regression docs if new behavior was added.
    - Run required usage scenarios when behavior affects end-to-end flows (see `docs/testing/usage-scenario-tests.md`) and record the scenario IDs.
    - Record validation/UAT sign-off (self-review OK for solo maintainer).
@@ -135,6 +138,7 @@ Use this once per repo to keep `main` safe without blocking work.
 - Testing status is documented when checks are skipped.
 - Backup/restore verification is documented when data flows change (or a waiver is recorded).
 - Documentation index/inventory updates are included when docs change.
+- Release notes updated for user-visible changes.
 - Testing workflow used for behavior changes, with pack IDs recorded.
 - Regression pack updates were considered for behavior changes, and TP-xx IDs were recorded before the PR.
 - Code review results are documented in the PR.
@@ -175,6 +179,8 @@ Use this once per repo to keep `main` safe without blocking work.
 - Folded `feature-all` into the `feature` prompt and clarified the state-aware flow.
 - Added a docs-impact gate to ensure documentation updates are completed or tracked with a doc child issue.
 - Clarified that feature finish/review invocation authorizes standard push/PR/merge steps after guard checks.
+- Added a release-notes update gate so user-facing changes are reflected in-app.
+- Added a build-info refresh step so the Home footer timestamp updates on feature finish while keeping the repo file clean.
 
 ## Related docs
 

--- a/docs/dev/workflows/release.md
+++ b/docs/dev/workflows/release.md
@@ -4,7 +4,7 @@ Use this workflow to ship a release to GitHub Pages for this app.
 
 - **Status**: Draft
 - **Owner**: repo maintainers
-- **Last updated**: 2026-01-03
+- **Last updated**: 2026-01-29
 - **Type**: How-to
 - **Scope**: release and deployment for biruks-egg-deliveries
 - **Non-goals**: changing deployment tooling or hosting strategy
@@ -19,6 +19,7 @@ Use this workflow to ship a release to GitHub Pages for this app.
 - Release scope (what changed).
 - Whether to run tests before shipping.
 - Next version tag (format `vYYYY.M.P`).
+- Release notes entry for the version being shipped.
 
 ## Constraints
 
@@ -26,6 +27,7 @@ Use this workflow to ship a release to GitHub Pages for this app.
 - Do not change deployment tooling without approval.
 - Confirm the version tag before releasing.
 - Prefer running the release flow via the `/release` prompt.
+- Update `public/release-notes.json` for the version being shipped before tagging or deploying.
 - Run full regression packs (TP-01 through TP-11) and usage scenarios before tagging or deploying to GitHub Pages.
 - Ensure required branch protection checks (for example `unit-tests`, `pr-body-validation`) are passing before release tags.
 
@@ -39,16 +41,19 @@ Use this workflow to ship a release to GitHub Pages for this app.
    - Execute TP-01 through TP-11 per `docs/testing/regression-tests.md`.
    - Execute `docs/testing/usage-scenario-tests.md`.
    - Record results (or explicitly document any skipped packs).
-4. If any packs are skipped, create a waiver record before deployment:
+4. Update release notes for the shipped version:
+   - Edit `public/release-notes.json` with a user-friendly summary.
+   - Ensure the newest release is listed first and uses plain language.
+5. If any packs are skipped, create a waiver record before deployment:
    - Note which packs were skipped, why, and who approved the skip.
    - Store the waiver in the release notes or a PR comment.
-4. Record device checklist status:
+6. Record device checklist status:
    - Note TP-11 device/PWA checks in release notes or a shared test log.
-5. Build the production bundle:
+7. Build the production bundle:
    - `npx ng build --configuration production --base-href="/biruks-egg-deliveries/"`
-6. Deploy to GitHub Pages:
+8. Deploy to GitHub Pages:
    - `npx angular-cli-ghpages --dir=dist/egg-delivery-app/browser --branch=gh-pages`
-7. Tag the release:
+9. Tag the release:
    - Use `vYYYY.M.P` format.
 
 ## Checks
@@ -56,6 +61,7 @@ Use this workflow to ship a release to GitHub Pages for this app.
 - Build completes without errors.
 - `gh-pages` branch updated.
 - Release tag created and pushed.
+- Release notes updated for the shipped version.
 - TP-11 device checklist status recorded.
 - Full regression packs and usage scenarios completed (or explicitly deferred with approval).
 - Waiver recorded when any packs are skipped.
@@ -71,6 +77,7 @@ Use this workflow to ship a release to GitHub Pages for this app.
 - Required full regression packs and usage scenarios before release tags and GH Pages deploys.
 - Added a waiver requirement for any skipped regression packs.
 - Noted required branch protection checks before release tags.
+- Added a release-notes update requirement so in-app updates stay current.
 
 ## Related docs
 

--- a/docs/ops/runbook.md
+++ b/docs/ops/runbook.md
@@ -4,7 +4,7 @@ Operational checks and troubleshooting steps for day-to-day app usage.
 
 - **Status**: Draft
 - **Owner**: repo maintainers
-- **Last updated**: 2025-12-24
+- **Last updated**: 2026-01-30
 - **Type**: How-to
 - **Scope**: operational health checks and common issues
 - **Non-goals**: deep debugging or code-level fixes
@@ -38,7 +38,9 @@ Operational checks and troubleshooting steps for day-to-day app usage.
 ### App out of date
 
 1. Check build info on Home.
-2. Reload the PWA or reinstall if the build info is stale.
+   - Build info is generated during the build/deploy step from `public/build-info.json`.
+2. If an **Update available** prompt appears, tap **Reload** to refresh to the latest build.
+3. Reload the PWA or reinstall if the build info is stale.
 
 ## Rollback
 

--- a/docs/testing/regression-tests.md
+++ b/docs/testing/regression-tests.md
@@ -4,7 +4,7 @@ This plan defines modular regression packs for the entire app so testing is reli
 
 - **Status**: Draft
 - **Owner**: repo maintainers
-- **Last updated**: 2025-12-30
+- **Last updated**: 2026-01-30
 - **Type**: How-to
 - **Scope**: end-to-end regression coverage across all app features
 - **Non-goals**: performance/load testing, backend API testing
@@ -356,11 +356,12 @@ Device matrix (minimum regression target):
 Notes:
 
 - Update these minimums when support policy changes or the device fleet shifts.
-- Wake lock is expected to be unsupported on iOS; confirm the fallback message.
+- The Keep screen awake toggle is currently hidden on Home while iOS wake lock support is unreliable.
 
 Manual checks:
 
-- Wake lock: toggle on/off and confirm the UI state and localStorage value update.
+- Wake lock: UI is currently hidden; validate toggle behavior via automated tests until re-enabled.
+- Service worker update: confirm the Update available prompt appears and Reload refreshes to the latest build.
 - Share/download: run Backup CSV and confirm the share sheet or download fallback.
 - Restore: follow the two-step backup-then-restore flow; confirm routes and history reload.
 - Maps: open a stop and confirm the deep link opens a maps app.

--- a/docs/user/user-guide.md
+++ b/docs/user/user-guide.md
@@ -4,7 +4,7 @@ How to use the app day‑to‑day: importing routes, planning, running deliverie
 
 - **Status**: Draft
 - **Owner**: repo maintainers
-- **Last updated**: 2025-12-26
+- **Last updated**: 2026-01-30
 - **Type**: How-to
 - **Scope**: end‑to‑end app usage for delivery weeks
 - **Non-goals**: developer setup or architectural detail
@@ -67,11 +67,12 @@ The Home page has four main sections:
 
 - **Settings**
   - **Dark mode**: toggle between light and dark themes.
-  - **Keep screen awake**: attempts to keep your screen on while using the app (depending on device support).
+  - **Keep screen awake**: temporarily hidden on iPhone while wake lock support is unreliable; may return later.
   - **Suggested donation/dozen**: the per‑dozen donation amount used when suggesting donation amounts on the Planner and Run pages.
 
 - **Build info**
   - Shows when the app was built and deployed, so you can see if your PWA is up to date.
+  - If an **Update available** prompt appears, tap **Reload** to apply the latest version.
 
 ---
 

--- a/docs/ux/style-guide.md
+++ b/docs/ux/style-guide.md
@@ -4,7 +4,7 @@ This style guide defines an iOS-inspired visual system for the Biruk's Egg Deliv
 
 - **Status**: Draft
 - **Owner**: repo maintainers
-- **Last updated**: 2026-01-02
+- **Last updated**: 2026-01-30
 - **Type**: Reference
 - **Scope**: visual system, UI components, and interaction patterns
 - **Non-goals**: implementation details for specific Angular components
@@ -523,8 +523,10 @@ If you use Tailwind, map these tokens into the theme so the same values power ut
 - **Layout**:
   - Card with import/backup/restore actions and timestamps.
   - Tax year selector card with multi-year warning when needed.
-  - Settings cards for dark mode, wake lock, suggested donation, and help.
+  - Settings cards for dark mode, suggested donation, and help.
+  - Keep screen awake is temporarily hidden while iPhone wake lock support is unreliable.
   - Build info card at the bottom.
+  - Update available prompt appears near the bottom when a new service worker version is ready.
 
 Example markup:
 

--- a/docs/ux/ux-overview.md
+++ b/docs/ux/ux-overview.md
@@ -4,7 +4,7 @@ Inventory of current screens, shared UI components, and styling touchpoints to k
 
 - **Status**: Draft
 - **Owner**: repo maintainers
-- **Last updated**: 2025-12-29
+- **Last updated**: 2026-01-30
 - **Type**: Reference
 - **Scope**: UI surfaces, shared components, and styling references
 - **Non-goals**: detailed visual specs (see style guide)
@@ -20,7 +20,7 @@ This document captures the current UI so we can keep the experience consistent w
   - Import CSV, backup CSV, and restore CSV (restore prompts for backup first).
   - Tax year selector with a multi-year warning for export accuracy.
   - “Suggested donation per dozen” setting.
-  - “Keep screen awake” and dark‑mode toggles.
+  - Dark mode toggle; Keep screen awake is temporarily hidden while iPhone wake lock support is unreliable.
   - Help overlay with the in-app guide.
   - Build info / last updated footer.
 
@@ -51,6 +51,8 @@ This document captures the current UI so we can keep the experience consistent w
 - **Services**
   - `StorageService` (Dexie‑backed local DB, suggested rate, wake lock state, etc.).
   - `BackupService` (CSV import/export, route/donation totals).
+- **App shell**
+  - Update available prompt appears near the bottom when a new service worker version is ready.
 - **Components**
   - `AppHeaderComponent` (logo, progress bar, and Home/Planner/Run navigation).
   - `DonationAmountPickerComponent` (shared amount selector used on Run and Planner).

--- a/public/release-notes.json
+++ b/public/release-notes.json
@@ -1,0 +1,49 @@
+[
+  {
+    "version": "v2026.1.2",
+    "date": "2026-01-29",
+    "summary": "Home now includes a Release Info button with recent updates.",
+    "highlights": [
+      "Release Info shows the latest updates in plain language.",
+      "Updates are ordered newest-first and available offline.",
+      "Update available prompt lets you reload to the newest version.",
+      "Keep screen awake is temporarily hidden on iPhone while support improves."
+    ]
+  },
+  {
+    "version": "v2026.1.1",
+    "date": "2026-01-29",
+    "summary": "Donation entry is smoother and now accepts five-digit amounts.",
+    "highlights": [
+      "Custom donation amounts stay when you choose Cash, ACH, Venmo, or PayPal.",
+      "Donations up to 99,999 are now accepted."
+    ]
+  },
+  {
+    "version": "v2026.1.0",
+    "date": "2026-01-03",
+    "summary": "Receipts and planner totals are clearer and more reliable.",
+    "highlights": [
+      "Receipt history totals match one-off donations more consistently.",
+      "Planner receipt edits have clearer validation."
+    ]
+  },
+  {
+    "version": "v2025.12.0",
+    "date": "2025-12-30",
+    "summary": "Backup/restore and run history tracking improved.",
+    "highlights": [
+      "Backup and restore flows are more reliable.",
+      "Run history exports include more complete details."
+    ]
+  },
+  {
+    "version": "v2025.11.0",
+    "date": "2025-11-15",
+    "summary": "Maintenance release with stability improvements.",
+    "highlights": [
+      "Reliability updates across core screens.",
+      "Minor copy and layout polish."
+    ]
+  }
+]

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -6,5 +6,32 @@
       <router-outlet></router-outlet>
     </main>
   </div>
+  @if (updateAvailable()) {
+    <div class="update-banner card" role="status" aria-live="polite">
+      <div>
+        <div class="update-title">Update available</div>
+        <div class="text-muted update-subtitle">
+          Reload to get the latest version.
+        </div>
+      </div>
+      <div class="update-actions">
+        <button
+          type="button"
+          class="btn btn-primary"
+          (click)="reloadForUpdate()"
+          [disabled]="updateInProgress()"
+        >
+          Reload
+        </button>
+        <button
+          type="button"
+          class="btn btn-secondary"
+          (click)="dismissUpdatePrompt()"
+        >
+          Later
+        </button>
+      </div>
+    </div>
+  }
   <app-toast />
 </div>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -33,3 +33,31 @@
 .app-shell.tight .card {
   margin-top: var(--spacing-1);
 }
+
+.update-banner {
+  position: fixed;
+  left: 50%;
+  bottom: calc(env(safe-area-inset-bottom, 0px) + var(--spacing-2));
+  transform: translateX(-50%);
+  width: min(420px, calc(100% - (var(--spacing-4) * 2)));
+  z-index: 2100;
+  display: grid;
+  gap: var(--spacing-2);
+  padding: var(--spacing-3);
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.2);
+}
+
+.update-title {
+  font-weight: var(--font-weight-semibold);
+}
+
+.update-subtitle {
+  font-size: var(--font-size-sm);
+}
+
+.update-actions {
+  display: flex;
+  gap: var(--spacing-2);
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,12 +1,23 @@
 import { TestBed } from '@angular/core/testing';
 import { AppComponent } from './app.component';
 import { provideRouter } from '@angular/router';
+import { SwUpdate, VersionReadyEvent } from '@angular/service-worker';
+import { Subject } from 'rxjs';
+
+class SwUpdateStub {
+  isEnabled = true;
+  versionUpdates = new Subject<VersionReadyEvent>();
+  activateUpdate = jasmine.createSpy().and.resolveTo();
+}
 
 describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [AppComponent],
-      providers: [provideRouter([])]
+      providers: [
+        provideRouter([]),
+        { provide: SwUpdate, useClass: SwUpdateStub }
+      ]
     }).compileComponents();
   });
 
@@ -14,5 +25,34 @@ describe('AppComponent', () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance;
     expect(app).toBeTruthy();
+  });
+
+  it('shows the update prompt when a new version is ready', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    const swUpdate = TestBed.inject(SwUpdate) as unknown as SwUpdateStub;
+    fixture.detectChanges();
+
+    swUpdate.versionUpdates.next({
+      type: 'VERSION_READY',
+      currentVersion: { hash: 'old', appData: {} },
+      latestVersion: { hash: 'new', appData: {} }
+    } as VersionReadyEvent);
+    fixture.detectChanges();
+
+    const banner = fixture.nativeElement.querySelector('.update-banner');
+    expect(banner).toBeTruthy();
+  });
+
+  it('reloads when the update prompt action runs', async () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    const component = fixture.componentInstance;
+    const swUpdate = TestBed.inject(SwUpdate) as unknown as SwUpdateStub;
+    const reloadSpy = spyOn(component as any, 'performReload');
+    fixture.detectChanges();
+
+    await component.reloadForUpdate();
+
+    expect(swUpdate.activateUpdate).toHaveBeenCalled();
+    expect(reloadSpy).toHaveBeenCalled();
   });
 });

--- a/src/app/pages/home.component.html
+++ b/src/app/pages/home.component.html
@@ -95,7 +95,8 @@
     <button
       type="button"
       class="btn"
-      [ngClass]="darkModeEnabled ? 'btn-primary' : 'btn-secondary'"
+      [class.btn-primary]="darkModeEnabled"
+      [class.btn-secondary]="!darkModeEnabled"
       (click)="toggleDarkMode()"
       title="Dark mode"
     >
@@ -104,29 +105,34 @@
   </div>
 </section>
 
-<section class="card settings-card">
-  <div class="settings-row">
-    <div>
-      <div class="settings-title">Keep screen awake</div>
-      <div class="text-muted settings-subtitle">
-        Prevents the display from sleeping while you use the app.
+@if (showWakeLockOption()) {
+  <section class="card settings-card">
+    <div class="settings-row">
+      <div>
+        <div class="settings-title">Keep screen awake</div>
+        <div class="text-muted settings-subtitle">
+          Prevents the display from sleeping while you use the app.
+        </div>
       </div>
+      <button
+        type="button"
+        class="btn"
+        [class.btn-primary]="wakeLockActive"
+        [class.btn-secondary]="!wakeLockActive"
+        (click)="toggleWakeLock()"
+        [disabled]="!wakeLockSupported"
+        title="Keep the screen awake while using the app"
+      >
+        {{ wakeLockActive ? "On" : "Off" }}
+      </button>
     </div>
-    <button
-      type="button"
-      class="btn"
-      [ngClass]="wakeLockActive ? 'btn-primary' : 'btn-secondary'"
-      (click)="toggleWakeLock()"
-      [disabled]="!wakeLockSupported"
-      title="Keep the screen awake while using the app"
-    >
-      {{ wakeLockActive ? "On" : "Off" }}
-    </button>
-  </div>
-  <div class="text-muted" *ngIf="!wakeLockSupported">
-    Screen wake lock is not supported on this device/browser.
-  </div>
-</section>
+    @if (!wakeLockSupported) {
+      <div class="text-muted">
+        Screen wake lock is not supported on this device/browser.
+      </div>
+    }
+  </section>
+}
 
 <section class="card settings-card">
   <div class="settings-row">
@@ -157,10 +163,29 @@
     <button
       type="button"
       class="btn"
-      [ngClass]="showHelp ? 'btn-primary' : 'btn-secondary'"
+      [class.btn-primary]="showHelp"
+      [class.btn-secondary]="!showHelp"
       (click)="toggleHelp()"
     >
       {{ showHelp ? "Hide" : "Help" }}
+    </button>
+  </div>
+  <div class="settings-row">
+    <div>
+      <div class="settings-title">Release info</div>
+      <div class="text-muted settings-subtitle">
+        See what’s new in the latest updates.
+      </div>
+    </div>
+    <button
+      type="button"
+      class="btn"
+      [class.btn-primary]="showReleaseInfo()"
+      [class.btn-secondary]="!showReleaseInfo()"
+      (click)="toggleReleaseInfo()"
+      aria-label="Release info"
+    >
+      {{ showReleaseInfo() ? "Hide" : "Info" }}
     </button>
   </div>
 </section>
@@ -267,3 +292,48 @@
     </div>
   </div>
 </div>
+
+@if (showReleaseInfo()) {
+  <div class="help-overlay release-overlay">
+    <div class="help-dialog card release-dialog">
+      <h3>Recent updates</h3>
+      <div class="help-content">
+        @if (visibleReleaseNotes().length) {
+          <div class="release-list">
+            @for (note of visibleReleaseNotes(); track note.version) {
+              <div class="release-note">
+                <div class="release-note-header">
+                  <span class="release-note-version">{{ note.version }}</span>
+                  @if (note.date) {
+                    <span class="text-muted release-note-date">
+                      {{ note.date | date : "MMM d, yyyy" : undefined : "en-US" }}
+                    </span>
+                  }
+                </div>
+                <p class="release-note-summary">
+                  {{ note.summary }}
+                </p>
+                @if (note.highlights?.length) {
+                  <ul>
+                    @for (item of note.highlights; track $index) {
+                      <li>{{ item }}</li>
+                    }
+                  </ul>
+                }
+              </div>
+            }
+          </div>
+        } @else {
+          <p class="text-muted">
+            {{
+              releaseNotesError() || "Release notes are unavailable right now."
+            }}
+          </p>
+        }
+      </div>
+      <div class="help-actions">
+        <!-- Release info is controlled by the toggle button. -->
+      </div>
+    </div>
+  </div>
+}

--- a/src/app/pages/home.component.scss
+++ b/src/app/pages/home.component.scss
@@ -251,3 +251,33 @@
   gap: var(--spacing-2);
   text-align: left;
 }
+
+.release-list {
+  display: grid;
+  gap: var(--spacing-3);
+}
+
+.release-note {
+  border-top: 1px solid var(--color-border);
+  padding-top: var(--spacing-3);
+}
+
+.release-note:first-child {
+  border-top: none;
+  padding-top: 0;
+}
+
+.release-note-header {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--spacing-2);
+  align-items: baseline;
+}
+
+.release-note-version {
+  font-weight: var(--font-weight-semibold);
+}
+
+.release-note-summary {
+  margin: var(--spacing-1) 0;
+}

--- a/src/app/services/release-notes.service.spec.ts
+++ b/src/app/services/release-notes.service.spec.ts
@@ -1,0 +1,45 @@
+import { TestBed } from '@angular/core/testing';
+import { ReleaseNote, ReleaseNotesService } from './release-notes.service';
+
+describe('ReleaseNotesService', () => {
+  let service: ReleaseNotesService;
+  let fetchSpy: jasmine.Spy;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ReleaseNotesService);
+  });
+
+  afterEach(() => {
+    if (fetchSpy) {
+      fetchSpy.and.callThrough();
+    }
+  });
+
+  it('returns parsed release notes and caches the result', async () => {
+    const notes: ReleaseNote[] = [
+      { version: 'v2026.1.1', date: '2026-01-29', summary: 'Update.' }
+    ];
+    fetchSpy = spyOn(globalThis, 'fetch').and.resolveTo({
+      ok: true,
+      json: async () => notes
+    } as Response);
+
+    const first = await service.load();
+    const second = await service.load();
+
+    expect(first).toEqual(notes);
+    expect(second).toEqual(notes);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null when the response is not ok', async () => {
+    fetchSpy = spyOn(globalThis, 'fetch').and.resolveTo({
+      ok: false
+    } as Response);
+
+    const result = await service.load();
+
+    expect(result).toBeNull();
+  });
+});

--- a/src/app/services/release-notes.service.ts
+++ b/src/app/services/release-notes.service.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@angular/core';
+
+export interface ReleaseNote {
+  version: string;
+  date?: string;
+  summary: string;
+  highlights?: string[];
+}
+
+@Injectable({ providedIn: 'root' })
+export class ReleaseNotesService {
+  private cache?: ReleaseNote[];
+
+  async load(): Promise<ReleaseNote[] | null> {
+    if (this.cache) return this.cache;
+    try {
+      const res = await fetch('release-notes.json', { cache: 'no-store' });
+      if (!res.ok) return null;
+      const data = (await res.json()) as unknown;
+      if (!Array.isArray(data)) return null;
+      const notes = data.filter(this.isReleaseNote);
+      this.cache = notes;
+      return notes;
+    } catch (err) {
+      console.warn('release notes fetch failed', err);
+      return null;
+    }
+  }
+
+  private isReleaseNote(value: unknown): value is ReleaseNote {
+    if (!value || typeof value !== 'object') return false;
+    const note = value as ReleaseNote;
+    return (
+      typeof note.version === 'string' &&
+      typeof note.summary === 'string' &&
+      (note.date === undefined || typeof note.date === 'string') &&
+      (note.highlights === undefined || Array.isArray(note.highlights))
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Add Release Info + Update available prompt, hide wake lock UI, and refresh workflows/docs.

## Linked work
- Fixes #168

## Change type
- [x] Feature
- [ ] Bugfix
- [ ] Refactor
- [x] Docs
- [ ] Chore/CI
- [ ] Security
- [ ] Performance

## Scope
- [x] UI
- [ ] Data/storage
- [ ] CSV/import/export
- [x] Testing/CI
- [x] Docs

## Review Evidence
- Behavior change (before/after)
  - Before: No Release Info list; no update prompt; Keep screen awake toggle shown on Home.
  - After: Release Info list + Update available prompt; Keep screen awake hidden (logic retained).
- Acceptance criteria covered
  - Release Info UI (latest 5, newest-first, offline, fallback)
  - Keep screen awake hidden on Home
  - Update available prompt reloads when SW update ready
  - Feature finish workflow includes build-info refresh
- Tests run (commands) + results
  - `npm test -- --watch=false --browsers=ChromeHeadless --include src/app/app.component.spec.ts --include src/app/pages/home.component.spec.ts --include src/app/services/release-notes.service.spec.ts` (pass; warnings about storage persistence, compound index suggestions, baseline-browser-mapping, and odd Node version)
  - `npm run build` (pass; warnings about baseline-browser-mapping, odd Node version, and bundle/style budgets)
- Automated specs updated
  - `src/app/app.component.spec.ts`
  - `src/app/pages/home.component.spec.ts`
  - `src/app/services/release-notes.service.spec.ts`
- Manual checks / TP packs
  - TP-01, TP-09, TP-11 (manual checks deferred)
- Risk assessment
  - Impacted areas: Home UI, app shell update prompt, docs/workflows.
  - Backward compatibility: none (additive UI + docs).
  - Security/data considerations: none.
  - Failure modes and mitigations: SW prompt will not appear in dev mode or if SW update is not ready; user can reload the PWA.
  - Rollback plan: revert this commit and redeploy.
- How to verify
  1. Open Home; Release Info button shows latest 5 notes newest-first and fallback message when notes missing.
  2. Confirm Keep screen awake is not shown on Home.
  3. In a prod build, trigger a SW update and confirm Update available banner reloads the app.

## Traceability

| Requirement/AC | Evidence (specs, TP-xx, manual checks) | Type (Auto/Manual) |
| --- | --- | --- |
| AC-1 Release Info list + ordering + fallback | `src/app/pages/home.component.spec.ts`, `src/app/services/release-notes.service.spec.ts` | Auto |
| AC-2 Release notes offline JSON | `src/app/services/release-notes.service.spec.ts` | Auto |
| AC-3 Keep screen awake hidden on Home | `src/app/pages/home.component.spec.ts` | Auto |
| AC-4 Update available prompt + reload | `src/app/app.component.spec.ts` | Auto |
| AC-5 Build-info refresh step in feature finish | `docs/dev/workflows/feature-delivery.md`, `.github/prompts/feature.prompt.md` | Manual |

## Docs impact
- [x] Docs updated
- [ ] Not needed (explain):

## Validation sign-off
- Usage scenarios run (IDs):
  - None
- Sign-off:
  - [x] Complete (self-review OK for solo work)

## Notes for reviewers
- Manual TP pack checks deferred; update prompt requires prod SW to validate.
- `public/build-info.json` restored before commit.

## PR size
- L

---

Review guidance: `docs/dev/workflows/code-review.md`

<!-- agent:labels -->
<!-- agent:release-notes -->
<!-- agent:risk -->
